### PR TITLE
Better way to find the end of results in SRC runs API

### DIFF
--- a/Data.py
+++ b/Data.py
@@ -18,21 +18,6 @@ class Data:
 		self.dead_runs = []
 		self.offset = 200
 
-	def getRuns(self):
-		try:
-			numRuns = re.compile('Number of runs.*?</div></div><div class=\"')
-			if self.gameAbbriveature == "":
-				self.gameAbbriveature = input(
-					"Enter the game's abbreviation in speedrun.com (eg. \"smb1\" for Super Mario Bros.): ")
-
-			stats = requests.get("https://www.speedrun.com/" + self.gameAbbriveature + "/gamestats")
-			if stats.status_code == 200:
-				self.runsCount = int(re.findall(numRuns, stats.text.replace('\t', '').replace('\n', '')).pop()\
-				.replace("Number of runs</div><div class=\"col-sm-6 row-list-text\">", "")\
-				.replace("</div></div><div class=\"", "").replace(',', ""))
-		except IndexError:
-			print("No such abbreviation was found\n")
-
 	def getNameID(self):
 		if self.gameAbbriveature == "":
 				self.gameAbbriveature = input("Enter the game's abbreviation in speedrun.com (eg. \"smb1\" for Super Mario Bros.): ")
@@ -48,12 +33,15 @@ class Data:
 	# Most likely, we'll have to add some extra code to check if link to video exists in comments. (Weird)
 	#
 	def getLinks(self):
-		for offset in range(0, self.runsCount+self.offset, self.offset):
+		offset = 0
+		noMoreResults = False
+		while not noMoreResults:
 			url = "https://www.speedrun.com/api/v1/runs?max=200&offset=" + \
 				str(offset) + "&status=verified&game=" + self.gameID
 			response = requests.get(url)
 			if response.status_code == 200:
-				data = response.json()['data']
+				responseJson = response.json()
+				data = responseJson['data']
 				for runs in data:
 					try:
 						try:
@@ -72,6 +60,12 @@ class Data:
 					except KeyError:
 						self.dead_runs.append(f"https://speedrun.com/{self.gameAbbriveature}/run/{runs['id']}")
 						continue
+				if responseJson.get('pagination').get('links'):
+					next_page = next((page['uri'] for page in responseJson['pagination']['links'] if page.get('rel') == 'next'), None)
+					if next_page:
+						offset += 200
+					else:
+						noMoreResults = True
 
 			self.youtubeLinks = [link for link in self.videoLinks for template in self.youtubeTemplate if template in link]
 			self.twitchLinks = [link for link in self.videoLinks for template in self.twitchTemplate if template in link]

--- a/Google.py
+++ b/Google.py
@@ -20,10 +20,18 @@ class GoogleAPI:
 			return True
 
 	def getVideoID(self, videoLink):
-		id = re.compile(r'[A-Za-z0-9_\-]{11}')
+		# FIXME: False positive arises because regex parses the channel names as well as the video id
+		# which means that the video id for the race will not be valid in the list to check, e.g.
+		# getVideoID(https://www.youtube.com/watch?v=<videoid>) -> <videoid>
+		# getVideoID(https://www.youtube.com/watch?v=<videoid>&ab_channel=<channelName>) -> channelName
+		# getVideoID(https://www.youtube.com/watch?v=<videoid>&list=<playlistid>&index=2) -> returns the last 11 characters of playlist id
+		#
+		# because the video id is associated with the run id, so if we pass on the channel name or part of the playlist, 
+		# google api decides that the link is invalid and marks the run with a broken link
+		id = re.compile(r'\/[A-Za-z0-9_\-]{11})',r'\=[A-Za-z0-9_\-]{11}')
 		videoID = re.findall(id, videoLink)
 		if videoID:
-			self.videoIDArray.append(videoID.pop())
+			self.videoIDArray.append(videoID.pop()[-1:])
 
 	def checkVideo(self):
 		for offset in range(0, len(self.videoIDArray)+self.offset, self.offset):

--- a/Google.py
+++ b/Google.py
@@ -31,7 +31,7 @@ class GoogleAPI:
 		id = re.compile(r'([A-Za-z0-9_\-]{11}).*')
 		videoID = re.findall(id, videoLink)
 		if videoID:
-			self.videoIDArray.append(videoID.pop()[1:])
+			self.videoIDArray.append(videoID.pop())
 
 	def checkVideo(self):
 		for offset in range(0, len(self.videoIDArray)+self.offset, self.offset):

--- a/Google.py
+++ b/Google.py
@@ -31,7 +31,7 @@ class GoogleAPI:
 		id = re.compile(r'\/[A-Za-z0-9_\-]{11})',r'\=[A-Za-z0-9_\-]{11}')
 		videoID = re.findall(id, videoLink)
 		if videoID:
-			self.videoIDArray.append(videoID.pop()[-1:])
+			self.videoIDArray.append(videoID.pop()[1:])
 
 	def checkVideo(self):
 		for offset in range(0, len(self.videoIDArray)+self.offset, self.offset):

--- a/Google.py
+++ b/Google.py
@@ -28,7 +28,7 @@ class GoogleAPI:
 		#
 		# because the video id is associated with the run id, so if we pass on the channel name or part of the playlist, 
 		# google api decides that the link is invalid and marks the run with a broken link
-		id = re.compile(r'\/[A-Za-z0-9_\-]{11})',r'\=[A-Za-z0-9_\-]{11}')
+		id = re.compile(r'([A-Za-z0-9_\-]{11}).*')
 		videoID = re.findall(id, videoLink)
 		if videoID:
 			self.videoIDArray.append(videoID.pop()[1:])

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ if __name__ == '__main__':
 	if twitch_status or google_status:
 		missed = []
 		data = Data.Data()
-		data.getRuns()
 		data.getNameID()
 		data.getLinks()
 

--- a/main.py
+++ b/main.py
@@ -22,7 +22,8 @@ if __name__ == '__main__':
 		#
 
 		for i in data.youtubeLinks:
-			link = google.getVideoID(i)
+			google.getVideoID(i)
+
 		missed = google.checkVideo()
 
 		for i in data.twitchLinks:
@@ -32,7 +33,7 @@ if __name__ == '__main__':
 
 		for miss in missed:
 			for run in data.runsArray:
-				if miss == run['link']:
+				if miss in run['link']:
 					data.dead_runs.append(
 						f"https://speedrun.com/{data.gameAbbriveature}/run/{run['runID']}")
 


### PR DESCRIPTION
We have been reliant on the html content of the game's stats page to find the number of runs, which is not great because any site update has a decent chance of breaking that piece of code.

Now I am using the pagination part of the API response and checking if there is a "next" section, if not then it means we have reached the end of results and hence can break the loop.